### PR TITLE
Don't require the user to provide a Dockerfile (Resolves #1)

### DIFF
--- a/lib/src/commands.dart
+++ b/lib/src/commands.dart
@@ -12,7 +12,6 @@ class GoldensRunner {
   static const argVerbose = "--verbose";
   static const argVerboseShort = "-v";
 
-  static const defaultDockerfilePath = "./golden_tester.Dockerfile";
   static const defaultDockerImageName = "golden_tester";
   static const defaultPathToProjectRoot = ".";
   static const defaultTestDirectoryPath = "test_goldens";
@@ -130,7 +129,7 @@ GoldenRequest parseTestCommandArguments(List<String> arguments) {
   GrLog.commands.fine("Test command arguments: $testCommandArguments");
 
   return GoldenRequest(
-    dockerFilePath: options[GoldensRunner.argDockerFilePath] ?? GoldensRunner.defaultDockerfilePath,
+    dockerFilePath: options[GoldensRunner.argDockerFilePath],
     dockerImageName: options[GoldensRunner.argDockerImageName] ?? GoldensRunner.defaultDockerImageName,
     packageDirectory: packageDirectory,
     pathToProjectRoot: options[GoldensRunner.argPathToProjectRoot] ?? GoldensRunner.defaultPathToProjectRoot,
@@ -175,7 +174,7 @@ String? _parseOption(List<String> arguments, String name) {
 
 class GoldenRequest {
   const GoldenRequest({
-    required this.dockerFilePath,
+    this.dockerFilePath,
     required this.dockerImageName,
     required this.packageDirectory,
     required this.pathToProjectRoot,
@@ -183,11 +182,14 @@ class GoldenRequest {
     required this.testCommandArguments,
   });
 
-  /// The path from the CLI command is running, to the Dockerfile that says
+  /// The path from where the CLI command is running, to the Dockerfile that says
   /// how to build the image.
   ///
+  /// When `null`, golden_runner uses its own version of a Dockerfile, which includes
+  /// a configuration that should suit typical users.
+  ///
   /// The file path must include the name of the file, e.g., `golden_tester.Dockerfile`.
-  final String dockerFilePath;
+  final String? dockerFilePath;
 
   /// The name to give the Docker image when its created.
   ///

--- a/test/arg_parsing_test.dart
+++ b/test/arg_parsing_test.dart
@@ -21,7 +21,7 @@ void main() {
       test("with test flags", () async {
         final goldenRequest = parseTestCommandArguments(["--verbose", "test_goldens"]);
 
-        expect(goldenRequest.dockerFilePath, './golden_tester.Dockerfile');
+        expect(goldenRequest.dockerFilePath, null);
         expect(goldenRequest.dockerImageName, 'golden_tester');
         expect(goldenRequest.pathToProjectRoot, '.');
         expect(goldenRequest.testBaseDirectory, 'test_goldens');


### PR DESCRIPTION
Don't require the user to provide a Dockerfile (Resolves #1)

This PR makes the Dockerfile path optional. When it's not provided, this PR alters the Docker command to specify the Dockerfile with `-f -` which tells Docker to check `stdin` for the Dockerfile. This PR then sends the Dockerfile content via `stdin`. As a result, users no longer need to know anything about Dockerfiles to use `golden_runner`.