### PR TITLE
Made Docker verbosity configurable, recovered color and interactive formatting for Flutter tests (Resolves #2)(Resolves #3)

### DIFF
--- a/special_test_goldens/README.md
+++ b/special_test_goldens/README.md
@@ -1,0 +1,3 @@
+This directory exists so that the tests for this package can point to
+a non-standard test directory, when testing incoming arguments. Do not
+put anything in this directory.

--- a/test/arg_parsing_test.dart
+++ b/test/arg_parsing_test.dart
@@ -4,46 +4,76 @@ import 'package:test/test.dart';
 void main() {
   group("Argument parsing >", () {
     group("test command >", () {
-      test("with golden flags", () async {
-        final goldenRequest = parseTestCommandArguments([
-          "--docker-file-path", "./some-dir/golden_tester.Dockerfile", //
-          "--docker-image-name", "my_tester_image", //
-          "--path-to-project-root", "../", //
-        ]);
+      test("with defaults", () async {
+        final goldenRequest = parseTestCommandArguments([]);
 
-        expect(goldenRequest.dockerFilePath, './some-dir/golden_tester.Dockerfile');
-        expect(goldenRequest.dockerImageName, 'my_tester_image');
-        expect(goldenRequest.pathToProjectRoot, '../');
-        expect(goldenRequest.testBaseDirectory, 'test_goldens');
-        expect(goldenRequest.testCommandArguments, []);
-      });
-
-      test("with test flags", () async {
-        final goldenRequest = parseTestCommandArguments(["--verbose", "test_goldens"]);
-
+        // Defaults.
         expect(goldenRequest.dockerFilePath, null);
         expect(goldenRequest.dockerImageName, 'golden_tester');
         expect(goldenRequest.pathToProjectRoot, '.');
         expect(goldenRequest.testBaseDirectory, 'test_goldens');
-        expect(goldenRequest.testCommandArguments, ["--verbose", "test_goldens"]);
+        expect(goldenRequest.testCommandArguments, []);
+        expect(goldenRequest.dockerVerbosity, DockerVerbosity.errorOnly);
       });
 
-      test("with golden flags and test flags", () async {
+      test("with all arguments", () async {
         final goldenRequest = parseTestCommandArguments([
           "--docker-file-path", "./some-dir/golden_tester.Dockerfile", //
           "--docker-image-name", "my_tester_image", //
+          "--docker-verbosity", "standard", //
           "--path-to-project-root", "../", //
           "--plain-name", "my test", //
           "--verbose",
-          "test_goldens",
+          "special_test_goldens",
         ]);
 
-        expect(goldenRequest.dockerFilePath, './some-dir/golden_tester.Dockerfile');
+        // Provided values.
+        expect(goldenRequest.dockerFilePath, "./some-dir/golden_tester.Dockerfile");
         expect(goldenRequest.dockerImageName, 'my_tester_image');
         expect(goldenRequest.pathToProjectRoot, '../');
-        expect(goldenRequest.testBaseDirectory, 'test_goldens');
-        expect(goldenRequest.testCommandArguments, ["--plain-name", "my test", "--verbose", "test_goldens"]);
+        expect(goldenRequest.testBaseDirectory, 'special_test_goldens');
+        expect(goldenRequest.testCommandArguments, ["--plain-name", "my test", "--verbose", "special_test_goldens"]);
+        expect(goldenRequest.dockerVerbosity, DockerVerbosity.standard);
       });
+    });
+
+    test("docker verbosity levels", () async {
+      expect(
+        parseTestCommandArguments([]).dockerVerbosity,
+        DockerVerbosity.errorOnly,
+      );
+
+      expect(
+        parseTestCommandArguments([
+          "--docker-verbosity",
+          "standard",
+        ]).dockerVerbosity,
+        DockerVerbosity.standard,
+      );
+
+      expect(
+        parseTestCommandArguments([
+          "--docker-verbosity",
+          "quiet",
+        ]).dockerVerbosity,
+        DockerVerbosity.quiet,
+      );
+
+      expect(
+        parseTestCommandArguments([
+          "--docker-verbosity",
+          "error",
+        ]).dockerVerbosity,
+        DockerVerbosity.errorOnly,
+      );
+
+      expect(
+        parseTestCommandArguments([
+          "--docker-verbosity",
+          "none",
+        ]).dockerVerbosity,
+        DockerVerbosity.none,
+      );
     });
   });
 }


### PR DESCRIPTION
Made Docker verbosity configurable, recovered color and interactive formatting for Flutter tests (Resolves #2)(Resolves #3)

**Docker Verbosity:**
Docker has different ways of controlling output across different comments. Sometimes you pass `-q`, sometimes you pass `--log-driver=none`, and sometimes all you can do is ignore `stdout`. I did the best I could to map the verbosity across our Docker commands.

**Flutter Test Colors & Formatting:**
This PR also brings back color and formatting for Flutter test output.

There were two things getting in the way of standard Flutter test output colors and formatting. First, Docker wasn't running as a terminal, which is apparently something Flutter can detect, so Flutter was turning off colors. This was fixed by passing `-t` to Docker, which runs as a terminal, bringing back colors. 

Then, the final issue was that every time `flutter test` output a status update line, it would print a new line. This resulted in dozens of lines of output per test, whereas normally `flutter test` keeps replacing the same line over and over to give the appearance of progress.  Apparently this is an ability that's tied to an "interactive" terminal. Therefore, to solve this, I added `-i` to Docker, and also told the Dart `Process` to inherit stdio, both of which appeared to be necessary to get the in-place progress display while running tests.

**Test Changes:**
I added a test for arg parsing all the Docker verbosity levels. When reading the existing tests, the way I named them and broke them down didn't make sense to me. Not sure what I meant by it. So I reconfigured the existing tests so that we have a test of all defaults, and a test with all arguments provided.